### PR TITLE
removed default sendRate value

### DIFF
--- a/src/TippingCanoe/Pushwoosh/Message.php
+++ b/src/TippingCanoe/Pushwoosh/Message.php
@@ -34,7 +34,7 @@
 		public $minimizeLink;
 
 		/** @var int */
-		public $sendRate = 100;
+		public $sendRate;
 		//
 		//
 		//


### PR DESCRIPTION
having default value for sendRate means it would always be sent to provider. sendRate doesn't work with devices property set. "Send rate throttling cannot be applied to messages sent to raw device tokens, only to bulk pushes or pushes with filter" - response when both values are sent
